### PR TITLE
#25497 - Add Matt Outten as an author on the has_breadcrumb gem

### DIFF
--- a/has_breadcrumb.gemspec
+++ b/has_breadcrumb.gemspec
@@ -6,7 +6,7 @@ require 'has_breadcrumb/version'
 Gem::Specification.new do |gem|
   gem.name          = "has_breadcrumb"
   gem.version       = HasBreadcrumb::VERSION
-  gem.authors       = ["Tim Harvey"]
+  gem.authors       = ["Tim Harvey", "Matt Outten"]
   gem.email         = ["developers@squaremouth.com"]
   gem.description   = %q{Provide breadcrumb links.}
   gem.summary       = %q{Provide links for the current page in a breadcrumb format.}


### PR DESCRIPTION
This pull request adds Matt Outten as an author to the gemspec.  Matt and Tim were the original coders who started this project hence why Matt needs added.  Currently the gemspec has only Tim Harvey.

[#25497](https://squaremouth.lighthouseapp.com/projects/63460-viper/tickets/25497-add-matt-as-an-author-on-the-has_breadcrumb)
