### PR TITLE
#25533 - Add gem dependencies and meta info to gemspec

### DIFF
--- a/has_breadcrumb.gemspec
+++ b/has_breadcrumb.gemspec
@@ -8,9 +8,9 @@ Gem::Specification.new do |gem|
   gem.version       = HasBreadcrumb::VERSION
   gem.authors       = ["Tim Harvey", "Matt Outten"]
   gem.email         = ["developers@squaremouth.com"]
-  gem.description   = %q{Provide breadcrumb links.}
-  gem.summary       = %q{Provide links for the current page in a breadcrumb format.}
-  gem.homepage      = ""
+  gem.description   = %q{Provides a simple and flexible way to create breadcrumbs with Rails active record models.}
+  gem.summary       = %q{Setting has_breadcrumb on a model will enable a view method, breadcrumb(), which will show the links to the page and its parents in a breadcrumb format.}
+  gem.homepage      = "https://github.com/sqm/has_breadcrumb"
 
   gem.files         = `git ls-files`.split($/)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
@@ -20,6 +20,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'activerecord', ['>= 3.0', '< 5.0']
   gem.add_dependency 'activesupport', ['>= 3.0', '< 5.0']
 
-  gem.add_development_dependency 'rspec-rails'
-  gem.add_development_dependency 'sqlite3'
+  gem.add_development_dependency 'rspec-rails', '~> 2.13'
+  gem.add_development_dependency 'sqlite3', '~> 1.3'
 end


### PR DESCRIPTION
This pull request is in response to some warnings encountered during the gem build process.  It adds a home page pointed to the gem's source code on Github, adds versions to the gem dependencies, and also improves the description and summary of the gem.

[#25533](https://squaremouth.lighthouseapp.com/projects/63460/tickets/25533-resolve-warnings-encountered-when-building-has_breadcrumb)
