### PR TITLE
Update rspec to version 3.0

### DIFF
--- a/lib/has_breadcrumb/version.rb
+++ b/lib/has_breadcrumb/version.rb
@@ -1,3 +1,3 @@
 module HasBreadcrumb
-  VERSION = "0.0.2"
+  VERSION = "0.0.3"
 end

--- a/simple_breadcrumbs.gemspec
+++ b/simple_breadcrumbs.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'activerecord', ['>= 3.0', '< 5.0']
   gem.add_dependency 'activesupport', ['>= 3.0', '< 5.0']
 
-  gem.add_development_dependency 'rspec-rails', '~> 2.13'
+  gem.add_development_dependency 'rspec-rails', '3.0'
   gem.add_development_dependency 'sqlite3', '~> 1.3'
   gem.add_development_dependency 'coveralls', '~> 0.7.0'
 end

--- a/spec/has_breadcrumb/has_breadcrumb_spec.rb
+++ b/spec/has_breadcrumb/has_breadcrumb_spec.rb
@@ -65,7 +65,7 @@ describe HasBreadcrumb do
 
   describe ".included" do
     it "should respond to has_breadcrumb" do
-      Father.should respond_to(:has_breadcrumb)
+      expect(Father).to respond_to(:has_breadcrumb)
     end
   end
 end

--- a/spec/has_breadcrumb/show_breadcrumb_spec.rb
+++ b/spec/has_breadcrumb/show_breadcrumb_spec.rb
@@ -30,7 +30,7 @@ describe ShowBreadcrumb do
   end
 
   describe "#breadcrumbs" do
-    before { controller.stub(url_for: "fake_url") }
+    before { allow(controller).to receive_messages(url_for: "fake_url") }
 
     context "when :forced_parent is passed" do
       it "should link to the forced parent" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,13 +27,7 @@ I18n.enforce_available_locales = false
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each {|f| require f}
 
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
-
-  # Run specs in random order to surface order dependencies. If you find an
-  # order dependency and want to debug it, you can fix the order by providing
-  # the seed, which is printed after each run.
-  #     --seed 1234
   config.order = 'random'
 end


### PR DESCRIPTION
In order to keep the test suite up to date for simple_breadcrumbs, this
commit updates rspec to version 3.0. It removes the deprecated should
syntax and instead uses expect syntax. In addition, it removes the
treat_symbols_as_metadata_keys_with_true_values rspec config option as
this is now the default behavior.
