### PR TITLE
Update dependencies for Rails 5.1 compatibility

### DIFF
--- a/lib/has_breadcrumb/version.rb
+++ b/lib/has_breadcrumb/version.rb
@@ -1,3 +1,3 @@
 module HasBreadcrumb
-  VERSION = "0.0.3"
+  VERSION = "0.0.4"
 end

--- a/simple_breadcrumbs.gemspec
+++ b/simple_breadcrumbs.gemspec
@@ -19,10 +19,10 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'activerecord', ['>= 3.0', '< 5.0']
-  gem.add_dependency 'activesupport', ['>= 3.0', '< 5.0']
+  gem.add_dependency 'activerecord', ['>= 3.0', '< 6']
+  gem.add_dependency 'activesupport', ['>= 3.0', '< 6']
 
-  gem.add_development_dependency 'rspec-rails', '3.0'
+  gem.add_development_dependency 'rspec-rails'
   gem.add_development_dependency 'sqlite3', '~> 1.3'
   gem.add_development_dependency 'coveralls', '~> 0.7.0'
 end


### PR DESCRIPTION
This commit updates the gems dependencies to allow it to be used with
Rails 5.1. To accomplish this, it increases the acceptable version range
for Active Record and Active Support for Rails 5.1, and removes the
version lock for rspec-rails to make it possible to use the proper
supported version corresponding to Active Record and Active Support.
No changes to the code were required.

