### PR TITLE
Update gemspec file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: ruby
 rvm:
-  - 1.9.3
+  - 1.9

--- a/simple_breadcrumbs.gemspec
+++ b/simple_breadcrumbs.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'activerecord', ['>= 3.0', '< 6']
   gem.add_dependency 'activesupport', ['>= 3.0', '< 6']
 
-  gem.add_development_dependency 'rspec-rails'
-  gem.add_development_dependency 'sqlite3', '~> 1.3'
+  gem.add_development_dependency 'rspec-rails', '~> 3.8'
+  gem.add_development_dependency 'sqlite3', '~> 1.3.13'
   gem.add_development_dependency 'coveralls', '~> 0.7.0'
 end


### PR DESCRIPTION
In order to remove the warnings when building the gem, this pull request
updates the gemspec to no longer have an open-ended version constraint
on the development dependency rspec-rails.