### PR TITLE
Update gem push to use latest 2.7 release

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.x
+          ruby-version: '2.7'
 
       - run: |
           mkdir -p $HOME/.gem

--- a/lib/has_breadcrumb/version.rb
+++ b/lib/has_breadcrumb/version.rb
@@ -1,3 +1,3 @@
 module HasBreadcrumb
-  VERSION = "1.0.2"
+  VERSION = "1.0.3"
 end


### PR DESCRIPTION
This commit fixes the ruby version to use the latest stable `2.7` when
pushing the gem to rubygems. This commit also bumps the gem version to
satisfy the version check.