### PR TITLE
Update SQM Gems gem-push.yml

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7'
+          ruby-version: 2.7
 
       - run: |
           mkdir -p $HOME/.gem

--- a/lib/has_breadcrumb/version.rb
+++ b/lib/has_breadcrumb/version.rb
@@ -1,3 +1,3 @@
 module HasBreadcrumb
-  VERSION = "1.0.4"
+  VERSION = "1.0.5"
 end


### PR DESCRIPTION
Updated to actions/checkout@v3 and ruby/setup-ruby@v1. Changed ruby version to 2.7, which expands to latest 2.7.X version.

[1203554587896808](https://app.asana.com/0/0/1203554587896808/f)