### PR TITLE
Update gem requirements for newer rails versions

### DIFF
--- a/lib/has_breadcrumb/version.rb
+++ b/lib/has_breadcrumb/version.rb
@@ -1,3 +1,3 @@
 module HasBreadcrumb
-  VERSION = "1.0.5"
+  VERSION = "1.1.0"
 end

--- a/simple_breadcrumbs.gemspec
+++ b/simple_breadcrumbs.gemspec
@@ -19,10 +19,10 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'activerecord', ['>= 3.0', '< 7']
-  gem.add_dependency 'activesupport', ['>= 3.0', '< 7']
+  gem.add_dependency 'activerecord', ['>= 3.0', '< 8']
+  gem.add_dependency 'activesupport', ['>= 3.0', '< 8']
 
-  gem.add_development_dependency 'rspec-rails', '~> 3.8'
-  gem.add_development_dependency 'sqlite3', '~> 1.3.13'
-  gem.add_development_dependency 'coveralls', '~> 0.7.0'
+  gem.add_development_dependency 'rspec-rails'
+  gem.add_development_dependency 'sqlite3'
+  gem.add_development_dependency 'coveralls'
 end


### PR DESCRIPTION
In order to support newer rails versions, this pull request updates the dependency requirements for activerecord and activesupport.

This pull request also removes unnecessary version constraints on the development dependencies of rspec-rails, sqlite3, and coveralls.